### PR TITLE
change memory from 512->256

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -23,7 +23,7 @@ applications:
   path: ./BluePic-Server
   command: BluePicServer
   random-route: true
-  memory: 512M
+  memory: 256M
   disk_quota: 1024M
   instances: 1
   buildpack: swift_buildpack


### PR DESCRIPTION
In anticipation of Bluemix's freemium changes, we should change the app memory from 512 to 256 (since 256 is in the free tier)