### PR TITLE
fix vision plan and use of random-route

### DIFF
--- a/.bluemix/pipeline.yml
+++ b/.bluemix/pipeline.yml
@@ -31,7 +31,7 @@ stages:
       cf create-service AppID Graduated\ tier BluePic-App-ID
       cf create-service imfpush Basic BluePic-IBM-Push
       cf create-service weatherinsights Free-v2 BluePic-Weather-Company-Data
-      cf create-service watson_vision_combined Free BluePic-Visual-Recognition
+      cf create-service watson_vision_combined free BluePic-Visual-Recognition
 
       cf push "${CF_APP}"
       # View logs

--- a/manifest.yml
+++ b/manifest.yml
@@ -22,7 +22,6 @@ applications:
 - name: BluePic
   path: ./BluePic-Server
   domain: mybluemix.net
-  host: BluePic
   command: BluePicServer
   random-route: true
   memory: 256M


### PR DESCRIPTION
Changes plan specifier for Watson Visual Recoginition in `.bluemix/pipeline.yml`

Remove deprecated `host` attribute in `manifest.yml` that conflicts with `random-route`

fixes #434 